### PR TITLE
- When a template is set to not-cached now also the preload query is …

### DIFF
--- a/GeeksCoreLibrary/Components/Account/Interfaces/IAccountsService.cs
+++ b/GeeksCoreLibrary/Components/Account/Interfaces/IAccountsService.cs
@@ -13,7 +13,7 @@ namespace GeeksCoreLibrary.Components.Account.Interfaces
         /// If the user has no cookie, the cookie contains an invalid value or the token is expired, it will return 0.
         /// </summary>
         /// <returns>If the user has no cookie, the cookie contains an invalid value or the token is expired, it will return 0, otherwise the ID of the user.</returns>
-        Task<UserCookieDataModel> GetUserDataFromCookieAsync(string cookieName = Constants.CookieName);
+        Task<UserCookieDataModel> GetUserDataFromCookieAsync(string cookieName = Constants.CookieName, bool skipRoles = false);
 
         /// <summary>
         /// Sometimes users want to place an order without creating an account. We do not want to login these users, but we do need an 'account' to link the order too.

--- a/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
+++ b/GeeksCoreLibrary/Components/OrderProcess/Services/OrderProcessesService.cs
@@ -802,8 +802,8 @@ namespace GeeksCoreLibrary.Components.OrderProcess.Services
 
                     webhookUrl = new UriBuilder(pspWebhookDomain);
                 }
-                // The PSP can't reach our development and test environments, so use the main domain in those cases.
-                else if (gclSettings.Environment.InList(Environments.Development, Environments.Test))
+                // The PSP can't reach our development and test environments, so use the main domain in those cases (except when NoPsp because we can test this locally)
+                else if (gclSettings.Environment.InList(Environments.Development, Environments.Test) && paymentMethodSettings.PaymentServiceProvider.Type!=PaymentServiceProviders.NoPsp)
                 {
                     var mainDomain = await objectsService.FindSystemObjectByDomainNameAsync("maindomain");
                     if (String.IsNullOrWhiteSpace(mainDomain))

--- a/GeeksCoreLibrary/Modules/Databases/Helpers/QueryHelpers.cs
+++ b/GeeksCoreLibrary/Modules/Databases/Helpers/QueryHelpers.cs
@@ -17,6 +17,7 @@ public static class QueryHelpers
         }
 
         return query.Contains("INSERT", StringComparison.OrdinalIgnoreCase) ||
+               query.Contains("CALL", StringComparison.OrdinalIgnoreCase) ||
                query.Contains("UPDATE", StringComparison.OrdinalIgnoreCase) ||
                query.Contains("DELETE", StringComparison.OrdinalIgnoreCase) ||
                query.Contains("ALTER", StringComparison.OrdinalIgnoreCase) ||

--- a/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/PagesService.cs
@@ -89,6 +89,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 WHERE {String.Join(" AND ", whereClause)}
                 GROUP BY template.template_id";
 
+                databaseConnection.ClearParameters();
                 var globalHeaders = await databaseConnection.GetAsync(query);
                 foreach (DataRow globalHeaderDataRow in globalHeaders.Rows)
                 {
@@ -157,6 +158,7 @@ namespace GeeksCoreLibrary.Modules.Templates.Services
                 WHERE {String.Join(" AND ", whereClause)}
                 GROUP BY template.template_id";
 
+                databaseConnection.ClearParameters();
                 var globalFooters = await databaseConnection.GetAsync(query);
                 foreach (DataRow globalFooterDataRow in globalFooters.Rows)
                 {

--- a/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Services/TemplatesService.cs
@@ -1380,7 +1380,7 @@ ORDER BY ORDINAL_POSITION ASC";
             }
 
             var query = await DoReplacesAsync(templatesService, template.PreLoadQuery, forQuery: true, templateType: TemplateTypes.Query);
-            var dataTable = await databaseConnection.GetAsync(query);
+            var dataTable = await databaseConnection.GetAsync(query, skipCache: template.CachingMinutes==-1);
             if (dataTable.Rows.Count == 0)
             {
                 return false;


### PR DESCRIPTION
…not cached. This did not work when querycaching was enabled by default in the appsettings.

- Added functionality to skip the query to get the roles for a user. This is usefull when we want to check the user login but don't want to deal with roles. It saves a query on each request.

- Added functionality to replace the default query to retreive user information by a custom query defined in easy_objects with a key called 'Account_CustomQuery'

- Added the keyword 'CALL' as a keyword to skip query caching by default, just like 'INSERT' and 'UPDATE'.

- Cleared parameters before executing the header and footer query for templates. Otherwise almost every query was unique so the header/footer retreival query was executed every request, even when this query was the same.

- Cleared parameters before getting the linktype settings. Otherwise this query was not cached correctly (because of existing parameters). That resulted in a lot more querys being executed.

- Getting the default ordering when getting the entity type settings. This information was not retreived and because of that ordering was saved even when the default ordering was set to alphabetic.

- Make sure the NoPSP payment method can be tested locally if we are running on the development environment. Before this change the noPSP was always changed to maindomain.

# Describe your changes

Please include a summary of the changes and relevant motivation and context.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [ ] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [ ] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

Add any open pull requests from other projects that are related to this pull request that should be merged along with this one. If there are none, you can simply say "none" or "N/A", or just leave this section empty.

# Link to Asana ticket

Add a link to the Asana ticket. Note that **_ONLY_** the URL should be added, not the name of the ticket!
