### PR TITLE
fix/array-to-object-for-sql-templates-without-grouping

### DIFF
--- a/GeeksCoreLibrary/Components/Account/Services/AccountsService.cs
+++ b/GeeksCoreLibrary/Components/Account/Services/AccountsService.cs
@@ -119,6 +119,7 @@ namespace GeeksCoreLibrary.Components.Account.Services
                                 AND entity_type = ?entityType
                                 AND expires > NOW()
                                 LIMIT 1";
+                }
 
                 databaseConnection.AddParameter("selector", cookieValueParts[0]);
                 databaseConnection.AddParameter("entityType", cookieValueParts[2]);

--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -323,12 +323,14 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
                 JToken jsonResult = await templatesService.GetJsonResponseFromQueryAsync(result);
                 
                 // If the template is expected to be returned as an object, check whether it is viable to do so and grab the first result as a JObject.
-                if (
-                    result.GroupingSettings.ObjectInsteadOfArray &&
-                    jsonResult is JArray jsonResultArray &&
-                    jsonResultArray.Count > 0)
-                    jsonResult = jsonResult[0] as JObject;
-
+                if (result.GroupingSettings.ObjectInsteadOfArray && jsonResult is JArray jsonResultArray)
+                {
+                    if (jsonResultArray.Count > 0)
+                        jsonResult = jsonResult[0] as JObject;
+                    else
+                        jsonResult = null;
+                }
+                
                 return Content(JsonConvert.SerializeObject(jsonResult), "application/json");
             }
             catch (Exception exception)

--- a/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
+++ b/GeeksCoreLibrary/Modules/Templates/Controllers/TemplatesController.cs
@@ -25,6 +25,7 @@ using GeeksCoreLibrary.Modules.Objects.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
 
 namespace GeeksCoreLibrary.Modules.Templates.Controllers
 {
@@ -319,7 +320,14 @@ namespace GeeksCoreLibrary.Modules.Templates.Controllers
                     stopWatch.Start();
                 }
 
-                var jsonResult = await templatesService.GetJsonResponseFromQueryAsync(result);
+                JToken jsonResult = await templatesService.GetJsonResponseFromQueryAsync(result);
+                
+                // If the template is expected to be returned as an object, check whether it is viable to do so and grab the first result as a JObject.
+                if (
+                    result.GroupingSettings.ObjectInsteadOfArray &&
+                    jsonResult is JArray jsonResultArray &&
+                    jsonResultArray.Count > 0)
+                    jsonResult = jsonResult[0] as JObject;
 
                 return Content(JsonConvert.SerializeObject(jsonResult), "application/json");
             }


### PR DESCRIPTION
It fixes an issue where returning an object rather than an array from an SQL template only worked when using grouping. Now, you can also get the result back as an object without having to group the query.