### PR TITLE
fix/evaluate-if-for-sql-templates

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Models/StringReplacementVariable.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Models/StringReplacementVariable.cs
@@ -28,5 +28,15 @@ namespace GeeksCoreLibrary.Modules.GclReplacements.Models
         /// The default value of the variable when given.
         /// </summary>
         public string DefaultValue { get; set; }
+        
+        /// <summary>
+        /// Whether the variable resides within a logic block.
+        /// </summary>
+        public bool IsInLogicBlock { get; set; }
+        
+        /// <summary>
+        /// The index position of the replacement variable in the input value.
+        /// </summary>
+        public int Index { get; set; }
     }
 }


### PR DESCRIPTION
Changed global replacement for variables in SQL templates to a distinguishment between variables in if-blocks and loose variables.

In more simple terms, before, a replacement would occur by looking for the matched string of a variable. As an example, in a query GCL/ICL looks for the string `{name}`. Despite the amount of occurrences of these variables, it would replace all of them at once, including those in an if-block. For queries, variables are replaced with query parameters. This means in the case of a query (SQL template), `{name}` becomes `?sql_name`. With this change, each occurrence is checked whether it is present in an if-block or whether it is not. With this change, in the case of a variable being in an if-block, it will directly replace `{name}` with its value and not parameterize the variable.

**This pull request may require a test run on a more scalable level. This pull request has been tested with "simple" queries. Complex queries may potentially cause unexpected behavior from this change.**