### PR TITLE
Fix: changed functionality to make sure webpage's with a fixed url ca…

### DIFF
--- a/GeeksCoreLibrary/Components/WebPage/Services/WebPagesService.cs
+++ b/GeeksCoreLibrary/Components/WebPage/Services/WebPagesService.cs
@@ -51,7 +51,7 @@ namespace GeeksCoreLibrary.Components.WebPage.Services
             for (var i = 1; i <= 5; i++)
             {
                 queryBuilder.AppendLine($"LEFT JOIN {WiserTableNames.WiserItemLink} AS link{i} ON link{i}.item_id = {(i == 1 ? "webPage.id" : $"parent{i - 1}.id")} And link{i}.type = 1");
-                queryBuilder.AppendLine($"LEFT JOIN {WiserTableNames.WiserItem} AS parent{i} ON parent{i}.id = link{i}.destination_item_id And parent{i}.published_environment >= ?publishedEnvironment");
+                queryBuilder.AppendLine($"LEFT JOIN {WiserTableNames.WiserItem} AS parent{i} ON parent{i}.id = IFNULL(link{i}.destination_item_id,{(i == 1 ? "webPage.parent_item_id" : $"parent{i - 1}.parent_item_id")}) And parent{i}.published_environment >= ?publishedEnvironment");
                 queryBuilder.AppendLine($"LEFT JOIN {WiserTableNames.WiserItemDetail} AS parentTitleSeo{i} ON parentTitleSeo{i}.item_id = parent{i}.id And parentTitleSeo{i}.`key` = '{CoreConstants.SeoTitlePropertyName}'");
             }
 
@@ -72,8 +72,9 @@ namespace GeeksCoreLibrary.Components.WebPage.Services
                 Id: firstRow.Field<ulong>("id"),
                 Title: firstRow.Field<string>("name"),
                 FixedUrl: fixedUrl,
-                Path: firstRow.Field<string>("path")?.Split('/').ToList(),
-                Parents: firstRow.Field<string>("parents")?.Split('/').Select(UInt64.Parse).ToList()
+                Path: firstRow.Field<string>("path")?.Split('/', StringSplitOptions.RemoveEmptyEntries).ToList(),
+                Parents: firstRow.Field<string>("parents")?.Split('/', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(UInt64.Parse).ToList()
             );
         }
 


### PR DESCRIPTION
# Describe your changes
Fix: changed functionality to make sure webpage's with a fixed url can also be retreived when they have no parent folder
Feature: if webpages are connected through parent_item_id instead of the wiser_itemlink table it now also works.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Checklist before requesting a review
- [X] I have reviewed and tested my changes in the Bestdeal project