### PR TITLE
feature/write-cookies-after-login

### DIFF
--- a/GeeksCoreLibrary/Components/Account/Models/AccountCmsSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Account/Models/AccountCmsSettingsModel.cs
@@ -1212,8 +1212,8 @@ namespace GeeksCoreLibrary.Components.Account.Models
             PrettyName = "Cookie name",
             Description = "Set cookie name if multiple account components with different accounts are used on the same page.",
             TabName = CmsAttributes.CmsTabName.Developer,
-            GroupName = CmsAttributes.CmsGroupName.Advanced,
-            DisplayOrder = 5,
+            GroupName = CmsAttributes.CmsGroupName.Cookies,
+            DisplayOrder = 10,
             ComponentMode = "LoginSingleStep,LoginMultipleSteps"
         )]
         public string CookieName { get; set; }
@@ -1227,7 +1227,7 @@ namespace GeeksCoreLibrary.Components.Account.Models
             DeveloperRemarks = "The cookie that is used in this component will always be deleted, not matter what you enter here.",
             TabName = CmsAttributes.CmsTabName.Developer,
             GroupName = CmsAttributes.CmsGroupName.Cookies,
-            DisplayOrder = 10,
+            DisplayOrder = 11,
             ComponentMode = "LoginSingleStep,LoginMultipleSteps"
         )]
         public string CookiesToDeleteAfterLogout { get; set; }
@@ -1241,7 +1241,7 @@ namespace GeeksCoreLibrary.Components.Account.Models
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.Developer,
             GroupName = CmsAttributes.CmsGroupName.Cookies,
-            DisplayOrder = 11,
+            DisplayOrder = 12,
             ComponentMode = "LoginSingleStep,LoginMultipleSteps"
         )]
         public string SessionKeysToDeleteAfterLogout { get; set; }
@@ -1255,7 +1255,7 @@ namespace GeeksCoreLibrary.Components.Account.Models
             DeveloperRemarks = "The cookies will be fetched from a given query and sent back in the response header.",
             TabName = CmsAttributes.CmsTabName.Developer,
             GroupName = CmsAttributes.CmsGroupName.Cookies,
-            DisplayOrder = 12,
+            DisplayOrder = 13,
             ComponentMode = "LoginSingleStep,LoginMultipleSteps"
         )]
         public bool WriteCookiesAfterLogin { get; set; }
@@ -1270,7 +1270,7 @@ namespace GeeksCoreLibrary.Components.Account.Models
             TabName = CmsAttributes.CmsTabName.Developer,
             GroupName = CmsAttributes.CmsGroupName.Cookies,
             TextEditorType = CmsAttributes.CmsTextEditorType.QueryEditor,
-            DisplayOrder = 13,
+            DisplayOrder = 14,
             ComponentMode = "LoginSingleStep,LoginMultipleSteps"
         )]
         public string WriteCookiesQuery { get; set; }

--- a/GeeksCoreLibrary/Components/Account/Models/AccountCmsSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Account/Models/AccountCmsSettingsModel.cs
@@ -1226,7 +1226,7 @@ namespace GeeksCoreLibrary.Components.Account.Models
             Description = "You can enter a comma separated list of cookie names to delete after the user logs out.",
             DeveloperRemarks = "The cookie that is used in this component will always be deleted, not matter what you enter here.",
             TabName = CmsAttributes.CmsTabName.Developer,
-            GroupName = CmsAttributes.CmsGroupName.Advanced,
+            GroupName = CmsAttributes.CmsGroupName.Cookies,
             DisplayOrder = 10,
             ComponentMode = "LoginSingleStep,LoginMultipleSteps"
         )]
@@ -1240,12 +1240,41 @@ namespace GeeksCoreLibrary.Components.Account.Models
             Description = "You can enter a comma separated list of session keys to delete after the user logs out.",
             DeveloperRemarks = "",
             TabName = CmsAttributes.CmsTabName.Developer,
-            GroupName = CmsAttributes.CmsGroupName.Advanced,
-            DisplayOrder = 20,
+            GroupName = CmsAttributes.CmsGroupName.Cookies,
+            DisplayOrder = 11,
             ComponentMode = "LoginSingleStep,LoginMultipleSteps"
         )]
         public string SessionKeysToDeleteAfterLogout { get; set; }
-
+        
+        /// <summary>
+        /// Whether to write cookies after a succesful login.
+        /// </summary>
+        [CmsProperty(
+            PrettyName = "Write cookies after login",
+            Description = "Whether to write cookies after a succesful login.",
+            DeveloperRemarks = "The cookies will be fetched from a given query and sent back in the response header.",
+            TabName = CmsAttributes.CmsTabName.Developer,
+            GroupName = CmsAttributes.CmsGroupName.Cookies,
+            DisplayOrder = 12,
+            ComponentMode = "LoginSingleStep,LoginMultipleSteps"
+        )]
+        public bool WriteCookiesAfterLogin { get; set; }
+        
+        /// <summary>
+        /// Whether to write cookies after a succesful login.
+        /// </summary>
+        [CmsProperty(
+            PrettyName = "Write cookies query",
+            Description = "The query to fetch the key-value pairs from to write to the cookies after a login.",
+            DeveloperRemarks = "The query has to return the columns `key` and `value`, representing a cookie entry.",
+            TabName = CmsAttributes.CmsTabName.Developer,
+            GroupName = CmsAttributes.CmsGroupName.Cookies,
+            TextEditorType = CmsAttributes.CmsTextEditorType.QueryEditor,
+            DisplayOrder = 13,
+            ComponentMode = "LoginSingleStep,LoginMultipleSteps"
+        )]
+        public string WriteCookiesQuery { get; set; }
+        
         #endregion
     }
 }

--- a/GeeksCoreLibrary/Core/Cms/Attributes/CmsAttributes.cs
+++ b/GeeksCoreLibrary/Core/Cms/Attributes/CmsAttributes.cs
@@ -65,7 +65,8 @@ namespace GeeksCoreLibrary.Core.Cms.Attributes
             Obsolete,
             [CmsEnum(PrettyName = "Sessions / Cookies")]
             SessionCookie,
-            Search
+            Search,
+            Cookies
         }
 
         /// <summary>

--- a/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
+++ b/GeeksCoreLibrary/Core/Helpers/HttpContextHelpers.cs
@@ -223,14 +223,17 @@ public static class HttpContextHelpers
     /// <param name="domain">Optional: The domain to associate the cookie with. Default is <see langword="null"/>.</param>
     /// <param name="httpOnly">Optional: Set to true if the cookie must not be accessible by client-side script. Default value is true. </param>
     /// <param name="isEssential">Indicates if this cookie is essential for the application to function correctly. If true then consent policy checks may be bypassed. The default value is false.</param>
-    public static void WriteCookie(HttpContext httpContext, string key, string value, DateTimeOffset? expires = null, string domain = null, bool httpOnly = true, bool isEssential = false)
+    /// <param name="secure">Optional: Set to true to mark the cookie as secure. Set to false otherwise. If the value is null (default), the security of the cookie will be determined based on whether the context is HTTPS.</param>
+    public static void WriteCookie(HttpContext httpContext, string key, string value, DateTimeOffset? expires = null, string domain = null, bool httpOnly = true, bool isEssential = false, bool? secure = null)
     {
+        secure ??= httpContext.Request.IsHttps;
+        
         var newCookieOptions = new CookieOptions
         {
             Expires = expires,
             Domain = domain,
             HttpOnly = httpOnly,
-            Secure = httpContext.Request.IsHttps,
+            Secure = secure.Value,
             IsEssential = isEssential,
             SameSite = GclSettings.Current.CookieSameSiteMode
         };


### PR DESCRIPTION
The functionality works! In an account component, you now have the option to enable or disable cookie writing after a login. Additionally, you can write cookies based on a query. In the query, you'll receive the userId (as {userId}) to execute a query with.

The query must return the columns "key" and "value." You can also include optional columns to further define the cookie:

expires_at → A DateTime indicating when the cookie should expire.
http_only → A boolean indicating whether the cookie should have the "HttpOnly" flag.
secure → A boolean indicating whether the cookie should have the "Secure" flag.

Example setup in Coder:
![image](https://github.com/user-attachments/assets/9f6bb769-75f1-4e07-a5e3-aa0a1d945c57)


Example result:
![image](https://github.com/user-attachments/assets/ffe21dde-515b-4743-b72d-88da8e734dee)