### PR TITLE
fix/loose-link-when-creating-item-with-invalid-link-values

### DIFF
--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -303,7 +303,9 @@ SELECT {(wiserItem.Id > 0 ? "?id" : "LAST_INSERT_ID()")} AS newId;";
                         }
                         await databaseConnection.ExecuteAsync($"UPDATE {tablePrefix}{WiserTableNames.WiserItem} SET parent_item_id = ?parentId, ordering = @newOrdering WHERE id = ?newItemId");
                     }
-                    else
+                    // If the link type states to not store the link as parent_id, but rather in a dedicated link table.
+                    // Additionally check if the link would be valid, by checking if neither the source, destination and type are "0" (invalid).
+                    else if(wiserItem.Id != 0 && parentId.Value != 0 && linkTypeNumber != 0)
                     {
                         var linkTablePrefix = wiserItemsService.GetTablePrefixForLink(linkTypeSettings);
 


### PR DESCRIPTION
Added a safeguard check when creating an item to not create a link alongside the item creation if the link values are considered "invalid".
