### PR TITLE
fix/details-not-deleted-through-sub-entity-grid

### DIFF
--- a/GeeksCoreLibrary/Core/Models/WiserItemDetailModel.cs
+++ b/GeeksCoreLibrary/Core/Models/WiserItemDetailModel.cs
@@ -4,7 +4,7 @@ namespace GeeksCoreLibrary.Core.Models
 {
     public class WiserItemDetailModel
     {
-        /*private ulong id;
+        private ulong id;
 
         /// <summary>
         /// Gets or sets the ID of the item detail.
@@ -21,7 +21,7 @@ namespace GeeksCoreLibrary.Core.Models
                 }
                 id = value;
             }
-        }*/
+        }
 
         private bool changed;
         private bool changedSetToFalseManually;

--- a/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
+++ b/GeeksCoreLibrary/Core/Services/WiserItemsService.cs
@@ -1190,7 +1190,15 @@ WHERE item.id = ?itemId");
                             //{
                             if (!isNewlyCreatedItem)
                             {
-                                deleteQueryBuilder.Add($"(`key` = ?key{counter} AND language_code = ?languageCode{counter})");                                
+                                if (string.IsNullOrEmpty(itemDetail.Key))
+                                {
+                                    deleteQueryBuilder.Add($"`id` = ?detail_id{counter}");
+                                    databaseConnection.AddParameter($"detail_id{counter}", itemDetail.Id);
+                                }
+                                else
+                                {
+                                    deleteQueryBuilder.Add($"(`key` = ?key{counter} AND language_code = ?languageCode{counter})");
+                                }
                             }
                             //}
                         }


### PR DESCRIPTION
Reverted the ID property from the WiserItemDetailModel which is necessary to delete item details without a key and value, but ones that have an ID.