### PR TITLE
fix/cms-settings-visiblity-for-non-legacy

### DIFF
--- a/GeeksCoreLibrary/Components/Repeater/Models/RepeaterCmsSettingsModel.cs
+++ b/GeeksCoreLibrary/Components/Repeater/Models/RepeaterCmsSettingsModel.cs
@@ -71,7 +71,7 @@ namespace GeeksCoreLibrary.Components.Repeater.Models
             TabName = CmsAttributes.CmsTabName.Layout,
             GroupName = CmsAttributes.CmsGroupName.Templates,
             DisplayOrder = 10,
-            ComponentMode = "NonLegacy",
+            ComponentMode = "NonLegacy,Repeater",
             HideInCms = false,
             ReadOnlyInCms = false
         )]

--- a/GeeksCoreLibrary/Components/Repeater/Models/RepeaterTemplateModel.cs
+++ b/GeeksCoreLibrary/Components/Repeater/Models/RepeaterTemplateModel.cs
@@ -12,7 +12,7 @@ namespace GeeksCoreLibrary.Components.Repeater.Models
             Description = "This template will be rendered once every time at the start of rendering this layer.",
             DeveloperRemarks = "",
             DisplayOrder = 10,
-            ComponentMode = "NonLegacy",
+            ComponentMode = "NonLegacy,Repeater",
             TextEditorType = CmsAttributes.CmsTextEditorType.HtmlEditor
         )]
         public string HeaderTemplate { get; set; } = "";
@@ -25,7 +25,7 @@ namespace GeeksCoreLibrary.Components.Repeater.Models
             Description = "This template will be rendered for every item/row of this layer.",
             DeveloperRemarks = "",
             DisplayOrder = 20,
-            ComponentMode = "NonLegacy",
+            ComponentMode = "NonLegacy,Repeater",
             TextEditorType = CmsAttributes.CmsTextEditorType.HtmlEditor
         )]
         public string ItemTemplate { get; set; } = "";
@@ -44,7 +44,7 @@ namespace GeeksCoreLibrary.Components.Repeater.Models
             Description = "This template will be rendered if the data source contains no data for this layer.",
             DeveloperRemarks = "",
             DisplayOrder = 30,
-            ComponentMode = "NonLegacy",
+            ComponentMode = "NonLegacy,Repeater",
             TextEditorType = CmsAttributes.CmsTextEditorType.HtmlEditor
         )]
         public string NoDataTemplate { get; set; } = "";
@@ -57,7 +57,7 @@ namespace GeeksCoreLibrary.Components.Repeater.Models
             Description = "This template will be rendered in between every 2 items/rows of this layer.",
             DeveloperRemarks = "",
             DisplayOrder = 40,
-            ComponentMode = "NonLegacy",
+            ComponentMode = "NonLegacy,Repeater",
             TextEditorType = CmsAttributes.CmsTextEditorType.HtmlEditor
         )]
         public string BetweenItemsTemplate { get; set; } = "";
@@ -70,7 +70,7 @@ namespace GeeksCoreLibrary.Components.Repeater.Models
             Description = "This template will be rendered once every time at the end of rendering this layer.",
             DeveloperRemarks = "",
             DisplayOrder = 50,
-            ComponentMode = "NonLegacy",
+            ComponentMode = "NonLegacy,Repeater",
             TextEditorType = CmsAttributes.CmsTextEditorType.HtmlEditor
         )]
         public string FooterTemplate { get; set; } = "";


### PR DESCRIPTION
Added "Repeater" as component mode to all CMS settings labeled "NonLegacy" to support dynamic visibility based on the selected component mode.
