### PR TITLE
String replacement now uses the correct ':' seperation

### DIFF
--- a/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
+++ b/GeeksCoreLibrary/Modules/GclReplacements/Services/ReplacementsMediator.cs
@@ -511,9 +511,10 @@ public class ReplacementsMediator : IReplacementsMediator, IScopedService
             // No check is performed to see if the formatters are valid, as that would slow things down too much.
             if (fieldName.Contains(':') && !fieldName.Trim().EndsWith(':'))
             {
-                var lastColonIndex = fieldName.LastIndexOf(":", StringComparison.Ordinal);
-                variableFormatters = fieldName[lastColonIndex..].TrimStart(':');
-                fieldName = fieldName[..lastColonIndex];
+                // find the next ':' after the first character
+                var firstColonIndex = fieldName.IndexOf(':', 1);
+                variableFormatters = fieldName[firstColonIndex..].TrimStart(':');
+                fieldName = fieldName[..firstColonIndex];
             }
 
             string evaluatedFieldSuffix = "_evaluated";


### PR DESCRIPTION
https://app.asana.com/1/236678296282156/project/1205519043178369/task/1212789367440343?focus=true